### PR TITLE
Make invocation of `>` more robust against future comparison impls on strings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn get_spot_prices(instance_type: &str, region: &str) -> Result<(), Box<dy
                 zones
                     .entry(zone.clone())
                     .and_modify(|(prev_ts, prev_price)| {
-                        if &timestamp > prev_ts {
+                        if timestamp > *prev_ts {
                             *prev_ts = timestamp.clone();
                             *prev_price = price;
                         }


### PR DESCRIPTION
The previous invocation could lead to inference failure if new impls on
strings became available.
